### PR TITLE
Update 08-python-setup.md to fix pyenv dependency install script

### DIFF
--- a/08-python-setup.md
+++ b/08-python-setup.md
@@ -81,7 +81,7 @@ Then, run this command to install the packages listed on the pyenv.
 ```shell
 sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
 libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git
 ```
 
 ## Apple Silicon ONLY: Install openssl and readline


### PR DESCRIPTION
python-openssl is not in the apt repositories as of Ubuntu 22.something or other, but python3-openssl actually IS in the repositories. I assume that this is the package you mean  to have us download